### PR TITLE
Add Supabase policies for org inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # a1a2vocab
+
+## Supabase migrations
+
+The project uses Supabase row level security policies to control who can create
+organizations and organization memberships. Before launching the application in
+any environment, make sure the policies in `supabase/migrations/` are applied to
+the target database.
+
+1. Install the Supabase CLI if you do not already have it: follow the
+   instructions at <https://supabase.com/docs/reference/cli/start>.
+2. Set the `project_id` in `supabase/config.toml` to the Supabase project ref
+   for the environment you want to update.
+3. Authenticate with Supabase and link the project:
+
+   ```sh
+   supabase login
+   supabase link --project-ref "$SUPABASE_PROJECT_REF"
+   ```
+
+4. Run the migrations (this will apply the policies defined in
+   `supabase/migrations/`):
+
+   ```sh
+   supabase db push
+   ```
+
+   If you prefer to target a specific database branch or the local development
+   database, pass the appropriate flags from the Supabase CLI documentation.
+
+Running `supabase db push` as part of your deployment or environment bootstrap
+ensures that the `p_orgs_insert` policy and the `org_members` insert policy are
+present before the application starts.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,10 @@
+project_id = "your-project-ref"
+
+[db]
+shadow_port = 54320
+port = 54322
+major_version = 15
+schema = ["public", "auth", "storage"]
+
+[migrations]
+dir = "supabase/migrations"

--- a/supabase/migrations/20240402000000_add_org_policies.sql
+++ b/supabase/migrations/20240402000000_add_org_policies.sql
@@ -1,0 +1,16 @@
+-- Ensure the policy for inserting new organizations exists
+DROP POLICY IF EXISTS "p_orgs_insert" ON public.orgs;
+CREATE POLICY "p_orgs_insert" ON public.orgs
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    (id = auth.uid())
+    OR (owner_id = auth.uid())
+  );
+
+-- Ensure members can only insert themselves into organizations
+DROP POLICY IF EXISTS "Insert org_members self" ON public.org_members;
+CREATE POLICY "Insert org_members self" ON public.org_members
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates insert policies for orgs and org_members
- configure Supabase CLI to pick up the new migrations directory
- document how to run the Supabase migration before launching the app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18f1cae7483218cdbdb0ca1a1398f