### PR TITLE
Handle Supabase sign-up errors gracefully

### DIFF
--- a/a1a2vocab.py
+++ b/a1a2vocab.py
@@ -1,4 +1,6 @@
 # streamlit_app.py  — Supabase version (multi-tenant)
+import logging
+
 import streamlit as st
 import pandas as pd
 from datetime import datetime, date
@@ -66,9 +68,14 @@ def auth_screen():
                 st.error("All fields required.")
             else:
                 # 1) Create auth user
-                out = sb.auth.sign_up({"email": email, "password": pw})
+                try:
+                    out = sb.auth.sign_up({"email": email, "password": pw})
+                except AuthApiError as err:
+                    logging.exception("Supabase sign-up failed: %s", err)
+                    st.error("Sign-up failed: email may already exist or confirmation required.")
+                    st.stop()
                 if not out.user:
-                    st.error("Sign-up failed.")
+                    st.error("Sign-up failed: email may already exist or confirmation required.")
                     st.stop()
 
                 # NOTE: if email confirmations are ON, user must confirm before login.


### PR DESCRIPTION
## Summary
- wrap the Supabase sign-up call in auth_screen with error handling and logging
- present a user-friendly message when sign-up fails or returns without a user

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e190073e2883218310c9722fe576d3