### PR TITLE
Ensure org insert sets owner id for new stores

### DIFF
--- a/a1a2vocab.py
+++ b/a1a2vocab.py
@@ -37,8 +37,14 @@ def success_rerun(msg: str):
 # -------------------------------
 def create_org_and_membership(user_id: str, org_name: str):
     # 1) create org
-    org = sb.table("orgs").insert({"name": org_name}).execute()
-    org_id = org.data[0]["id"]
+    org_insert = sb.table("orgs").insert({
+        "name": org_name,
+        "owner_id": user_id,
+    }).execute()
+    org_data = org_insert.data or []
+    if not org_data or "id" not in org_data[0]:
+        raise RuntimeError("Failed to create organization")
+    org_id = org_data[0]["id"]
     # 2) add membership (requires insert policy on org_members)
     sb.table("org_members").insert({
         "user_id": user_id,


### PR DESCRIPTION
## Summary
- include the authenticated owner when inserting new org rows so Supabase policies pass
- validate the insert response still returns the org id before creating the membership record

## Testing
- not run (Supabase credentials not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e1914e99e08321aedf562aea075438