### PR TITLE
Fix indentation for store creation helper

### DIFF
--- a/a1a2vocab.py
+++ b/a1a2vocab.py
@@ -215,7 +215,7 @@ def list_sales(org_id: str) -> pd.DataFrame:
     res = sb.table("sales").select("*").eq("org_id", org_id).order("created_at", desc=True).limit(50).execute()
     return pd.DataFrame(res.data or [])
 
- def create_store_for_logged_in_user(store_name: str):
+def create_store_for_logged_in_user(store_name: str):
     uid = st.session_state["user"]["id"]
     set_token(st.session_state.get("jwt"))
     org = sb.table("orgs").insert({"name": store_name}).execute()  # <-- only 'name'


### PR DESCRIPTION
## Summary
- fix the indentation of create_store_for_logged_in_user so it matches other top-level functions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e19592ac3c8321aefda4ce8bf9f79c