### PR TITLE
Remove undefined set_token call during store creation

### DIFF
--- a/a1a2vocab.py
+++ b/a1a2vocab.py
@@ -217,7 +217,6 @@ def list_sales(org_id: str) -> pd.DataFrame:
 
 def create_store_for_logged_in_user(store_name: str):
     uid = st.session_state["user"]["id"]
-    set_token(st.session_state.get("jwt"))
     org = sb.table("orgs").insert({"name": store_name}).execute()  # <-- only 'name'
     org_id = org.data[0]["id"]
     sb.table("org_members").insert({


### PR DESCRIPTION
## Summary
- remove the undefined `set_token` call when creating a store so the flow no longer raises a `NameError`

## Testing
- python -m compileall a1a2vocab.py

------
https://chatgpt.com/codex/tasks/task_e_68e196455d3883219bf11f2977899fcd