### PR TITLE
Include owner id when creating orgs

### DIFF
--- a/a1a2vocab.py
+++ b/a1a2vocab.py
@@ -126,13 +126,18 @@ def create_store_for_logged_in_user(store_name: str) -> str:
     # (Optional) Show identity the DB sees
     check_db_identity()
 
+    user_id = st.session_state["user"]["id"]
+
     # 1) create org (INSERT policy should allow any authenticated user)
-    org = sb.table("orgs").insert({"name": store_name}).execute()
+    org = sb.table("orgs").insert({
+        "name": store_name,
+        "owner_id": user_id,
+    }).execute()
     org_id = org.data[0]["id"]
 
     # 2) create membership for current user (org owner)
     sb.table("org_members").insert({
-        "user_id": st.session_state["user"]["id"],
+        "user_id": user_id,
         "org_id": org_id,
         "role": "owner"
     }).execute()


### PR DESCRIPTION
## Summary
- reuse the logged-in user's ID when creating new orgs
- persist the owner ID on the org record
- ensure the membership insert references the same owner ID

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e240853574832197574cd0108a3be6