### PR TITLE
Handle Supabase session reattachment failures

### DIFF
--- a/a1a2vocab.py
+++ b/a1a2vocab.py
@@ -83,8 +83,16 @@ def reattach_session():
     access = st.session_state.get("jwt")
     refresh = st.session_state.get("rt")
     if access and refresh:
-        sb.auth.set_session(access_token=access, refresh_token=refresh)
-        sb.postgrest.auth(access)
+        try:
+            sb.auth.set_session(access_token=access, refresh_token=refresh)
+            sb.postgrest.auth(access)
+        except AuthApiError:
+            for key in ("user", "jwt", "rt", "org_id", "role"):
+                st.session_state.pop(key, None)
+            st.warning("Session expired. Please log in again.")
+        except Exception:
+            for key in ("user", "jwt", "rt", "org_id", "role"):
+                st.session_state.pop(key, None)
 
 def logout():
     """Clear only local state; do not try to unauth PostgREST with None token."""


### PR DESCRIPTION
## Summary
- wrap Supabase session reattachment in error handling to avoid reusing expired tokens
- clear cached auth details and notify the user when reattachment fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e241aa4a70832183f1562ef6fd1370